### PR TITLE
added check for 0 energy in controller event listener

### DIFF
--- a/game.html
+++ b/game.html
@@ -177,6 +177,8 @@
     <script>
         game_map.update();
         document.onkeydown = function (e) {
+          if (game_map.hero.display_energy() >= 0)
+          {
             switch (e.keyCode) {
                 case 37: // left
                     e.preventDefault();
@@ -195,6 +197,7 @@
                     game_map.move_south();
                     break;
             }
+          }
         }
     </script>
   </body>

--- a/game.html
+++ b/game.html
@@ -177,8 +177,6 @@
     <script>
         game_map.update();
         document.onkeydown = function (e) {
-          if (game_map.hero.display_energy() >= 0)
-          {
             switch (e.keyCode) {
                 case 37: // left
                     e.preventDefault();
@@ -197,7 +195,6 @@
                     game_map.move_south();
                     break;
             }
-          }
         }
     </script>
   </body>

--- a/map.js
+++ b/map.js
@@ -95,6 +95,9 @@ Map.prototype.move_west = function()
 
 Map.prototype.move = function(x,y)
 {
+    // exit function early if hero has no energy
+    if(this.hero.energy <= 0)
+      return;
     nextx = (this.hero.x + x) % this.width;
     nexty = (this.hero.y + y) % this.height;
     if(nextx < 0)


### PR DESCRIPTION
Addressing the issue of the user still moving across the map with negative energy. Tested by moving across the screen to verify the issue then tested after the fix. 